### PR TITLE
Fix Tidier with storageUnit datafile

### DIFF
--- a/src/main/java/org/icatproject/ids/storage/DfInfoImpl.java
+++ b/src/main/java/org/icatproject/ids/storage/DfInfoImpl.java
@@ -7,7 +7,7 @@ import org.icatproject.ids.plugin.DfInfo;
 public class DfInfoImpl implements DfInfo {
 
 	private String createId;
-	private long dfId;
+	private Long dfId;
 	private String dfLocation;
 	private String dfName;
 	private String modId;


### PR DESCRIPTION
In the case of storageUnit datafile with the standard plugin ids.storage_file the Tidier never archives any file.  In the ids.log one can find entries like:

```
2016-04-06 15:30:37,962 DEBUG [Timer-10] Tidier$Action - SELECT df FROM Datafile df \
WHERE df.id = 0 AND df.location = '48/215/f8251036-196c-4d2a-b391-19eeba73a353' \
INCLUDE df.dataset LIMIT 0,500 returns 0 datafiles
```

Note the condition `df.id = 0`, this will certainly not return anything.

The cause is that class DfInfoImpl defines the field `dfId` as `long` rather then `Long`. As a consequence, if this field is not set, the getter returns zero rather then null.  And since the value is not null, it is included in the condition to search for the Datafile.
