### PR TITLE
Fix file leak in ArchiveFileStorage.restore()

### DIFF
--- a/src/main/java/org/icatproject/ids/storage/ArchiveFileStorage.java
+++ b/src/main/java/org/icatproject/ids/storage/ArchiveFileStorage.java
@@ -99,6 +99,7 @@ public class ArchiveFileStorage implements ArchiveStorageInterface {
 			try {
 				InputStream is = Files.newInputStream(baseDir.resolve(dfInfo.getDfLocation()));
 				mainStorageInterface.put(is, location);
+				is.close();
 			} catch (IOException e) {
 				failures.add(dfInfo);
 			}


### PR DESCRIPTION
The restore() method of ArchiveFileStorage opens an InputStream for each file it restores.  But it never closes them. As a result, the glassfish process keeps all the restored files open in the archive storage.
