### PR TITLE
Add configuration option testHome in settings.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,17 @@
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.20.1</version>
+				<configuration>
+					<systemPropertyVariables>
+						<testHome>${testHome}</testHome>
+					</systemPropertyVariables>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<version>2.4.1</version>
 				<configuration>

--- a/src/test/java/org/icatproject/ids/storage/MainFileStorageTest.java
+++ b/src/test/java/org/icatproject/ids/storage/MainFileStorageTest.java
@@ -3,11 +3,11 @@ package org.icatproject.ids.storage;
 import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
@@ -48,11 +48,12 @@ public class MainFileStorageTest {
 	@BeforeClass
 	public static void beforeClass() throws IOException, ClassNotFoundException, InterruptedException {
 
+		Path dir = Paths.get(System.getProperty("testHome"), "storage_file");
+		Files.createDirectories(dir);
 		Properties props = new Properties();
-		props.load(MainFileStorageTest.class.getClassLoader().getResourceAsStream("main.test.properties"));
+		props.setProperty("plugin.main.dir", dir.toString());
 		mainFileStorage = new MainFileStorage(props);
 
-		Path dir = new File(props.getProperty("plugin.main.dir")).toPath();
 		if (dir != null) {
 			if (Files.exists(dir)) {
 				Files.walkFileTree(dir, treeDeleteVisitor);

--- a/src/test/resources/main.test.properties
+++ b/src/test/resources/main.test.properties
@@ -1,1 +1,0 @@
-plugin.main.dir = /home/fisher/test


### PR DESCRIPTION
Add a configuration option "testHome" to be set in settings.xml. The main storage directory to be used during the tests is created relative to this directory. This is related to icatproject/ids.server#81.