### PR TITLE
Bump icat.utils to 4.16.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>org.icatproject</groupId>
 			<artifactId>icat.utils</artifactId>
-			<version>4.16.0</version>
+			<version>4.16.1-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>org.icatproject</groupId>
 			<artifactId>icat.utils</artifactId>
-			<version>4.16.1-SNAPSHOT</version>
+			<version>4.16.1</version>
 		</dependency>
 
 		<dependency>

--- a/src/site/xdoc/release-notes.xml
+++ b/src/site/xdoc/release-notes.xml
@@ -11,6 +11,8 @@
 		<section name="devel">
 			<p>Development, no yet released</p>
 			<ul>
+				<li>#8: Bump icat.utils to version 4.16.1.
+				</li>
 				<li>#7: Bump junit to version 4.13.1.
 				</li>
 			</ul>


### PR DESCRIPTION
Bump the dependency on `icat.utils` to 4.16.1 (released on 2021-02-11).  This adds Python 3 compatibility for the `setup` script.