### PR TITLE
Use python3 instead of python

### DIFF
--- a/src/main/scripts/setup
+++ b/src/main/scripts/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from setup_utils import *
 import os
 

--- a/src/site/xdoc/release-notes.xml
+++ b/src/site/xdoc/release-notes.xml
@@ -8,6 +8,14 @@
 
 	<body>
 
+		<section name="devel">
+			<p>Development, no yet released</p>
+			<ul>
+				<li>#9: Use python3 instead of python in the interpreter line of setup.py
+				</li>
+			</ul>
+		</section>
+
 		<section name="1.4.3">
 			<p>Compatibility with Python 3</p>
 			<ul>


### PR DESCRIPTION
Modern distros often don't have a `python` command, so use `python3` explicitly.